### PR TITLE
enable mapbox-rgb encoded terrain layers

### DIFF
--- a/src/renderer/components/OSD.js
+++ b/src/renderer/components/OSD.js
@@ -31,6 +31,6 @@ export const OSD = () => {
     <div className='osd__cell' style={styles.C}>{ state.C2 }</div>
     <div className='osd__cell' style={styles.A}></div>
     <div className='osd__cell' style={styles.B}></div>
-    <div className='osd__cell' style={styles.C}></div>
+    <div className='osd__cell' style={styles.C}>{ state.C3 }</div>
   </div>
 }

--- a/src/renderer/components/properties/TilePresetProperties.js
+++ b/src/renderer/components/properties/TilePresetProperties.js
@@ -43,6 +43,7 @@ const Opacity = props => {
  */
 const Layer = props => {
 
+  // terrain data layers must not be invisible, thus we hide controls
   const icons = props.contentType?.includes('terrain')
     ? <Icon
         path={mdiTerrain}
@@ -81,6 +82,7 @@ const Layer = props => {
           <Tooltip anchorSelect='.tt-tile-preset-opacity' content='Change the opacity' delayShow={750}/>
           <Tooltip anchorSelect='.tt-tile-preset-handle' content='Drag to change the order of visibility' delayShow={750}/>
           <Tooltip anchorSelect='.tt-tile-preset-visibility' content='Hide/Show this map' delayShow={750}/>
+          <Tooltip anchorSelect='.tt-tile-preset-terrain' content='This layer contains terrain data' delayShow={750}/>
         </div>
         <Opacity
           opacity={props.opacity}

--- a/src/renderer/components/properties/TilePresetProperties.js
+++ b/src/renderer/components/properties/TilePresetProperties.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import SortableList, { SortableItem } from 'react-easy-sort'
 import Icon from '@mdi/react'
-import { mdiDrag, mdiEyeOutline, mdiEyeOff, mdiSquareOpacity } from '@mdi/js'
+import { mdiDrag, mdiEyeOutline, mdiEyeOff, mdiSquareOpacity, mdiTerrain } from '@mdi/js'
 import { useServices, useList } from '../hooks'
 import Range from './Range'
 import { Tooltip } from 'react-tooltip'
@@ -41,8 +41,32 @@ const Opacity = props => {
 /**
  *
  */
-const Layer = props => (
-  <SortableItem>
+const Layer = props => {
+
+  const icons = props.contentType?.includes('terrain')
+    ? <Icon
+        path={mdiTerrain}
+        size='24px'
+        className=' tt-tile-preset-terrain'
+        style={{ marginLeft: 'auto' }}
+      />
+    : <>
+        <Icon
+            path={mdiSquareOpacity}
+            size='24px'
+            className=' tt-tile-preset-opacity'
+            style={{ marginLeft: 'auto' }}
+            onClick={props.onSelect}
+          />
+          <Icon
+            path={props.visible ? mdiEyeOutline : mdiEyeOff}
+            size='24px'
+            onClick={props.onToggleVisible}
+            className='tt-tile-preset-visibility'
+          />
+      </>
+
+  return (<SortableItem>
 
     {/* react-easy-sort kills list style => add necessary margins.  */}
     <div
@@ -53,19 +77,7 @@ const Layer = props => (
         <div className='bf12-row'>
           <Icon path={mdiDrag} size='24px' className='tt-tile-preset-handle'/>
           <span className='bf12-card__description'>{props.name}</span>
-          <Icon
-            path={mdiSquareOpacity}
-            size='24px'
-            style={{ marginLeft: 'auto' }}
-            className=' tt-tile-preset-opacity'
-            onClick={props.onSelect}
-          />
-          <Icon
-            path={props.visible ? mdiEyeOutline : mdiEyeOff}
-            size='24px'
-            onClick={props.onToggleVisible}
-            className='tt-tile-preset-visibility'
-          />
+          { icons }
           <Tooltip anchorSelect='.tt-tile-preset-opacity' content='Change the opacity' delayShow={750}/>
           <Tooltip anchorSelect='.tt-tile-preset-handle' content='Drag to change the order of visibility' delayShow={750}/>
           <Tooltip anchorSelect='.tt-tile-preset-visibility' content='Hide/Show this map' delayShow={750}/>
@@ -78,7 +90,8 @@ const Layer = props => (
       </div>
     </div>
   </SortableItem>
-)
+  )
+}
 
 
 /**
@@ -118,16 +131,17 @@ const LayerList = props => {
     tileLayerStore.toggleVisible(props.preset, id)
   }
 
-  const layers = list.entries.map(entry =>
-    <Layer
-      key={entry.id}
-      {...entry}
-      selected={list.selected.includes(entry.id)}
-      onSelect={handleSelect(entry.id)}
-      onOpacityChange={handleOpacityChange(entry.id)}
-      onToggleVisible={handleToggleVisible(entry.id)}
-    />
-  )
+  const layers = list.entries
+    .map(entry =>
+      <Layer
+        key={entry.id}
+        {...entry}
+        selected={list.selected.includes(entry.id)}
+        onSelect={handleSelect(entry.id)}
+        onOpacityChange={handleOpacityChange(entry.id)}
+        onToggleVisible={handleToggleVisible(entry.id)}
+      />
+    )
 
   // There seems to be no way to have decent CSS on list container.
   // We workaround this by applying ad-hoc styles.
@@ -148,8 +162,11 @@ const LayerList = props => {
 /**
  *
  */
-const TilePresetProperties = props => (
+const TilePresetProperties = props => {
+  console.dir(props)
+  return (
   <LayerList preset={Object.entries(props.features)[0]}/>
-)
+  )
+}
 
 export default TilePresetProperties

--- a/src/renderer/model/OSDDriver.js
+++ b/src/renderer/model/OSDDriver.js
@@ -67,12 +67,23 @@ OSDDriver.prototype.pointermove = function ({ coordinate, map, pixel }) {
   this.emitter.emit('osd', { message, cell: 'C2' })
 
   const candids = map?.getLayerGroup().getLayersArray()
-  const terrainLayer = candids.find(l => l.get('contentType') === 'terrain/mapbox-rgb')
-  if (!terrainLayer) return
-  const data = terrainLayer.getData(pixel)
-  if (!data) return
-  const value = elevation(data)
-  const elevationMessage = value ? `${value.toFixed(1)}m` : ''
+  const terrainLayers = candids.filter(l => l.get('contentType') === 'terrain/mapbox-rgb')
+  if (terrainLayers.length === 0) {
+    this.emitter.emit('osd', { message: '', cell: 'C3' })
+    return
+  }
+
+  const data = terrainLayers
+    .map(l => l.getData(pixel))
+    .map(d => elevation(d))
+    .filter(Boolean)
+
+  if (data.length === 0) {
+    this.emitter.emit('osd', { message: '', cell: 'C3' })
+    return
+  }
+
+  const elevationMessage = `${data[0].toFixed(1)}m`
   this.emitter.emit('osd', { message: elevationMessage, cell: 'C3' })
 }
 

--- a/src/renderer/model/OSDDriver.js
+++ b/src/renderer/model/OSDDriver.js
@@ -25,6 +25,13 @@ const formats = {
   UTM: ([lng, lat]) => new LatLon(lat, lng).toUtm().toString()
 }
 
+const elevation = rgb => {
+  if (!rgb) return null
+  const value = -10000 + (((rgb[0] << 16) + (rgb[1] << 8) + rgb[2]) * 0.1)
+  if (value === -10000) return null
+  return value
+}
+
 export const OSDDriver = function (projectUUID, emitter, preferencesStore, projectStore, store) {
   this.projectUUID = projectUUID
   this.emitter = emitter
@@ -51,13 +58,22 @@ export const OSDDriver = function (projectUUID, emitter, preferencesStore, proje
   })
 }
 
-OSDDriver.prototype.pointermove = function ({ coordinate }) {
+OSDDriver.prototype.pointermove = function ({ coordinate, map, pixel }) {
   this.lastCoordinate = coordinate
 
   if (!this.coordinatesFormat) return
   const lonLat = toLonLat(coordinate)
   const message = formats[this.coordinatesFormat](lonLat)
   this.emitter.emit('osd', { message, cell: 'C2' })
+
+  const candids = map?.getLayerGroup().getLayersArray()
+  const terrainLayer = candids.find(l => l.get('contentType') === 'terrain/mapbox-rgb')
+  if (!terrainLayer) return
+  const data = terrainLayer.getData(pixel)
+  if (!data) return
+  const value = elevation(data)
+  const elevationMessage = value ? `${value.toFixed(1)}m` : ''
+  this.emitter.emit('osd', { message: elevationMessage, cell: 'C3' })
 }
 
 OSDDriver.prototype.updateDateTime = function () {

--- a/src/renderer/store/TileLayerStore.js
+++ b/src/renderer/store/TileLayerStore.js
@@ -258,14 +258,10 @@ TileLayerStore.prototype.updateLayers = async function (preset) {
   const currentLayers = this.layerCollection.getArray()
   const findLayer = id => currentLayers.find(layer => layer.get('id') === id)
   const services = Object.fromEntries(await this.store.tuples(ID.TILE_SERVICE_SCOPE))
-  // console.dir(preset)
-
+ 
   const updateLayer = (layer, properties, index) => {
-    /* console.dir(layer) */
-    console.dir(properties)
-
-    layer.setOpacity(properties.opacity)
-    layer.setVisible(properties.visible)
+    layer.setOpacity(properties.contentType ? 0 : properties.opacity)
+    layer.setVisible(properties.contentType ? 1 : properties.visible)
     layer.setZIndex(0 - index)
     layer.set('contentType', properties.contentType)
     return layer

--- a/src/renderer/store/documents/tile-service.js
+++ b/src/renderer/store/documents/tile-service.js
@@ -8,7 +8,7 @@ export default async function (id) {
   const document = {
     id,
     scope: ID.TILE_SERVICE,
-    text: service.name,
+    text: service?.name || '',
     tags: [...(tags || []), service.type]
   }
 

--- a/src/renderer/store/options/tile-service.js
+++ b/src/renderer/store/options/tile-service.js
@@ -11,9 +11,12 @@ export default async function (id) {
     scope: service.type,
     tags: [
       `SCOPE:${service.type}:NONE`,
-      ...((tags || [])).map(label => `USER:${label}:NONE`),
+      (tags || []).some(t => t === 'TERRAIN') ? 'SYSTEM:TERRAIN::mdiTerrain' : null,
+      ...((tags || []))
+        .filter(Boolean)
+        .filter(t => t !== 'TERRAIN').map(label => `USER:${label}:NONE`),
       'PLUS'
-    ].join(' '),
+    ].filter(Boolean).join(' '),
     capabilities: 'TAG|RENAME'
   }
 


### PR DESCRIPTION
In order to display the elevation, calculate line-of-sight, terrain profiles, viewsheds etc. we need to find a way to use digital elevation model (DEM) data. Mapbox developed a way to encode elevation data in RGB tiles. This way the mechanisms to load elevation data is the same as regular basemaps.

This PR enables mapbox-rgb tiles that contain tab-encoded elevation data.