### PR TITLE
fix: Use webUtils.getPathForFile() for file drag-and-drop links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 jsdoc/
 .vscode
 .env
+docs/mdview*.html

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,4 +1,3 @@
-import * as R from 'ramda'
 import { app, dialog, ipcMain, shell, BrowserWindow, protocol, session, net } from 'electron'
 import fs from 'fs'
 import path from 'path'
@@ -143,16 +142,12 @@ const ready = async () => {
   })
 
   ipcMain.on('OPEN_LINK', async (event, link) => {
-    const fileURLToPath = URL.fileURLToPath
-    const openPath = shell.openPath
-    const openExternal = url => shell.openExternal(url, { activate: true })
-
-    const open =
-      link.url.startsWith('file:')
-        ? R.compose(openPath, fileURLToPath)
-        : openExternal
-
-    open(link.url)
+    if (link.url.startsWith('file:')) {
+      const filePath = URL.fileURLToPath(link.url)
+      await shell.openPath(filePath)
+    } else {
+      shell.openExternal(link.url, { activate: true })
+    }
   })
 
   ipcMain.on('RELOAD_ALL_WINDOWS', () => {

--- a/src/main/preload/preload.js
+++ b/src/main/preload/preload.js
@@ -1,3 +1,4 @@
+const { webUtils } = require('electron')
 const projects = require('./modules/projects')
 const replication = require('./modules/replication')
 const collaboration = require('./modules/collaboration')
@@ -17,5 +18,6 @@ window.odin = {
   window: window_,
   preferences,
   editing,
-  platform
+  platform,
+  webUtils
 }

--- a/src/renderer/components/projectlist/Card.js
+++ b/src/renderer/components/projectlist/Card.js
@@ -56,7 +56,8 @@ export const Card = React.forwardRef((props, ref) => {
       // Process files first (if any):
       const [...files] = event.dataTransfer.files
       const fileLinks = files.reduce((acc, file) => {
-        const url = new URL(`file:${file.path}`)
+        const filePath = window.odin.webUtils.getPathForFile(file)
+        const url = new URL(`file:${filePath}`)
         const value = { name: file.name, url: url.href }
         acc.push([linkId(id), value])
         return acc

--- a/src/renderer/components/sidebar/Card.js
+++ b/src/renderer/components/sidebar/Card.js
@@ -48,7 +48,8 @@ const useDragAndDrop = (id, acceptDrop) => {
     // Process files first (if any):
     const [...files] = event.dataTransfer.files
     const fileLinks = files.reduce((acc, file) => {
-      const url = new URL(`file:${file.path}`)
+      const filePath = window.odin.webUtils.getPathForFile(file)
+      const url = new URL(`file:${filePath}`)
       const value = { name: file.name, url: url.href }
       acc.push([ID.linkId(id), value])
       return acc


### PR DESCRIPTION
File.path was removed in Electron 38. Dropped files had undefined paths, resulting in `file:///undefined` URLs.

**Changes:**
- Use `webUtils.getPathForFile()` (exposed via preload) instead of `file.path`
- Simplify OPEN_LINK handler, remove unused ramda import
- Fix applies to both sidebar/Card.js and projectlist/Card.js