### PR TITLE
fix: Default properties panel to open for new projects

### DIFF
--- a/specs/properties-panel-default-open.md
+++ b/specs/properties-panel-default-open.md
@@ -1,0 +1,48 @@
+# Properties Panel Default: Open on Selection
+
+## Overview
+
+When a new project is created in ODIN, the properties panel should be open by
+default. This means that selecting a feature or layer on the map will
+immediately show its properties in the side panel. Users can toggle the panel
+off if they prefer a cleaner workspace.
+
+## Background
+
+The properties panel visibility is controlled by the `ui.properties`
+preference, persisted via `useMemento`. The possible values are:
+
+| Value | Effect |
+|-------|--------|
+| `''` (empty string) | No panel shown |
+| `'properties'` | Properties panel shown |
+| `'styles'` | Styles panel shown |
+| `'sharing'` | Sharing panel shown |
+
+The default value (used when no preference has been stored yet, i.e. in a new
+project) was `''`, meaning the panel is closed. This is confusing for new users
+who expect to see properties when selecting items on the map.
+
+## Change
+
+Set the default value of `ui.properties` from `''` to `'properties'` in both
+components that consume this preference:
+
+- `src/renderer/components/Project.js` — renders the panel conditionally
+- `src/renderer/components/Toolbar.js` — toggles the panel and shows the
+  active state of the toolbar button
+
+This only affects **new projects** (or projects where the user has never
+toggled the panel). Existing projects retain their stored preference.
+
+## Acceptance Criteria
+
+1. In a newly created project, the properties panel is visible by default
+   (equivalent to `ui.properties === 'properties'`).
+2. Selecting a feature on the map shows its properties immediately without
+   having to click the properties toolbar button first.
+3. Users can close the panel by clicking the properties toolbar button; the
+   preference is persisted and the panel remains closed on next open.
+4. Users can re-open the panel by clicking the toolbar button again.
+5. Existing projects with a stored `ui.properties` value are not affected.
+6. The properties toolbar button shows as active/checked in new projects.

--- a/src/renderer/components/Project.js
+++ b/src/renderer/components/Project.js
@@ -21,7 +21,7 @@ export const Project = () => {
   const { emitter } = useServices()
   const [sidebarShowing] = useMemento('ui.sidebar.showing', true)
   const [toolbarShowing] = useMemento('ui.toolbar.showing', true)
-  const [properties] = useMemento('ui.properties', '')
+  const [properties] = useMemento('ui.properties', 'properties')
 
   const [toolbarScope, setToolbarScope] = React.useState('STANDARD')
 

--- a/src/renderer/components/Toolbar.js
+++ b/src/renderer/components/Toolbar.js
@@ -8,7 +8,7 @@ import { NIDOPopover } from './NIDOPopover'
 
 
 export const Toolbar = () => {
-  const [properties, setProperties] = useMemento('ui.properties', '')
+  const [properties, setProperties] = useMemento('ui.properties', 'properties')
   const { commandRegistry, replicationProvider } = useServices()
 
   const commands = [

--- a/test/renderer/properties-panel-default-test.js
+++ b/test/renderer/properties-panel-default-test.js
@@ -1,0 +1,42 @@
+import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+
+// Verify that the default value for ui.properties is 'properties' (panel open)
+// in all components that consume this preference. This is a source-level test
+// to prevent accidental regressions.
+
+const SRC = path.resolve('src/renderer/components')
+
+const extractMementoDefault = (source, key) => {
+  // Match useMemento('ui.properties', <default>)
+  const pattern = new RegExp(`useMemento\\s*\\(\\s*'${key}'\\s*,\\s*'([^']*)'\\s*\\)`)
+  const match = source.match(pattern)
+  return match ? match[1] : null
+}
+
+describe('Properties panel default value', function () {
+
+  it('Project.js defaults ui.properties to "properties"', function () {
+    const source = fs.readFileSync(path.join(SRC, 'Project.js'), 'utf8')
+    const defaultValue = extractMementoDefault(source, 'ui.properties')
+    assert.equal(defaultValue, 'properties',
+      'Project.js should default ui.properties to "properties" so the panel is open for new projects')
+  })
+
+  it('Toolbar.js defaults ui.properties to "properties"', function () {
+    const source = fs.readFileSync(path.join(SRC, 'Toolbar.js'), 'utf8')
+    const defaultValue = extractMementoDefault(source, 'ui.properties')
+    assert.equal(defaultValue, 'properties',
+      'Toolbar.js should default ui.properties to "properties" so the toolbar button shows as active')
+  })
+
+  it('Project.js and Toolbar.js use the same default', function () {
+    const projectSource = fs.readFileSync(path.join(SRC, 'Project.js'), 'utf8')
+    const toolbarSource = fs.readFileSync(path.join(SRC, 'Toolbar.js'), 'utf8')
+    const projectDefault = extractMementoDefault(projectSource, 'ui.properties')
+    const toolbarDefault = extractMementoDefault(toolbarSource, 'ui.properties')
+    assert.equal(projectDefault, toolbarDefault,
+      'Both components must use the same default value for ui.properties to avoid inconsistency')
+  })
+})


### PR DESCRIPTION
## Change

The properties panel is now **open by default** in new projects. Previously, the default was closed (`''`), which confused users who expected to see properties when selecting features on the map.

### What changed

The default value of `ui.properties` changed from `''` to `'properties'` in:
- `src/renderer/components/Project.js` — renders the panel
- `src/renderer/components/Toolbar.js` — toolbar toggle button

### Behaviour

- **New projects**: Properties panel is visible. Selecting a feature/layer shows its properties immediately.
- **Existing projects**: No change. The stored preference is respected.
- **User control**: Users can close the panel via the toolbar button. Their choice is persisted.

### Spec & Tests

- Spec: `specs/properties-panel-default-open.md`
- Tests: `test/renderer/properties-panel-default-test.js` (3 tests verifying default values and consistency)