### PR TITLE
feat: Add MGRS graticule overlay

### DIFF
--- a/src/renderer/components/map/Map.js
+++ b/src/renderer/components/map/Map.js
@@ -61,7 +61,7 @@ export const Map = () => {
     })
 
     registerEventHandlers({ services, sources, vectorLayers, map })
-    registerGraticules({ services, map })
+    registerGraticules({ services, map, vectorLayers })
     print({ map, services })
 
     // Force map resize on container resize:

--- a/src/renderer/components/map/mgrsGraticule.js
+++ b/src/renderer/components/map/mgrsGraticule.js
@@ -744,7 +744,6 @@ export const createMGRSGraticule = (map) => {
   const source = new VectorSource()
   const layer = new VectorLayer({
     source,
-    zIndex: 1,
     updateWhileAnimating: false,
     updateWhileInteracting: false
   })


### PR DESCRIPTION
## Summary

Adds an MGRS (Military Grid Reference System) graticule overlay to the map, selectable via **View → Graticules → MGRS**.

## Features

- **Grid Zone Designations (GZD)** — always visible, with zone+band labels (e.g. `32V`)
- **100 km grid** — appears at resolution ≤ 1200 m/px with 100k square letter labels (e.g. `KM`)
- **10 km grid** — appears at resolution ≤ 120 m/px with digit labels (e.g. `3 · 7`)
- **1 km grid** — appears at resolution ≤ 12 m/px with 2-digit labels (e.g. `32 · 74`)
- **UTM special zones**: Norway (31V/32V) and Svalbard (31X/33X/35X/37X) with per-latitude clipping
- **Graceful fallback** for cursor coordinates outside UTM limits (>84°N / <80°S)

## Visual

- Red-toned lines for visibility on light and dark basemaps
- Graticule renders below feature layers (correct z-ordering)
- Lines clip smoothly at zone boundaries, no gaps between zones

## Technical

- Single module: `src/renderer/components/map/mgrsGraticule.js`
- Uses `geodesy/mgrs.js` for UTM/MGRS conversions
- `clipToZone()` for per-latitude zone clipping at special zone boundaries
- `verticalLineSamples()` adds extra interpolation points at band transitions (56°N, 64°N, 72°N)
- Spec: `specs/mgrs-graticule.md`

## Changes

- `src/renderer/components/map/mgrsGraticule.js` — new MGRS graticule layer
- `src/renderer/components/map/graticules.js` — layer insertion below features
- `src/renderer/components/map/Map.js` — pass vectorLayers to graticule registration
- `src/renderer/model/OSDDriver.js` — handle coordinates outside UTM limits