### PR TITLE
fix: Enable emoji extension for Material icons in docs

### DIFF
--- a/docs-src/mkdocs.yml
+++ b/docs-src/mkdocs.yml
@@ -51,6 +51,9 @@ markdown_extensions:
   - tables
   - attr_list
   - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - toc:
       permalink: true
 


### PR DESCRIPTION
The `:material-*:` icons in the Quick Links section require the `pymdownx.emoji` extension. This adds it to mkdocs.yml.