### PR TITLE
fix: Enable pymdownx.keys for keyboard shortcut rendering

### DIFF
--- a/docs-src/mkdocs.yml
+++ b/docs-src/mkdocs.yml
@@ -54,6 +54,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.keys
   - toc:
       permalink: true
 


### PR DESCRIPTION
Adds the `pymdownx.keys` extension so `++ctrl+n++` renders as proper keyboard badges instead of raw text.