### PR TITLE
fix: render blue dot fallback for point features without SIDC

### DIFF
--- a/src/renderer/ol/style/symbol.js
+++ b/src/renderer/ol/style/symbol.js
@@ -32,6 +32,20 @@ export default $ => {
     }
 
     const sidc = properties.sidc
+
+    // Fallback: features without an SIDC (and without a custom SVG) would
+    // otherwise produce a Style with no image and stay invisible on the map.
+    // Render OpenLayers' canonical blue dot so the feature is at least locatable.
+    if (!sidc) {
+      return [{
+        id: 'style:default/bluedot',
+        'circle-radius': 6,
+        'circle-fill-color': 'rgba(51,153,204,1)',
+        'circle-line-color': '#ffffff',
+        'circle-line-width': 1.5
+      }]
+    }
+
     const modifiers = Object.entries(properties)
       .filter(([key, value]) => MODIFIERS[key] && value)
       .reduce((acc, [key, value]) => R.tap(acc => (acc[MODIFIERS[key]] = value), acc), {})


### PR DESCRIPTION
## Problem

Point features arriving via the ODIN `LiveDataSource` (implemented as `SSEVectorSource`) were not visible on the map when the incoming GeoJSON carried neither an `sidc` property nor a custom `svg` property — even though data was clearly flowing.

### Root cause

In `src/renderer/ol/style/symbol.js`, the style spec for point features was built unconditionally as:

```js
return [{
  id: 'style:2525c/symbol',
  'symbol-code': sidc,
  'symbol-modifiers': modifiers
}]
```

When `sidc` is missing, `symbol-code` becomes `undefined`. The style spec then flows into `styleFactory.makeImage` (`src/renderer/ol/style/styleFactory.js:188-195`):

```js
const makeImage = props => {
  if (props['icon-image']) return makeCanvasIcon(props)
  else if (props['circle-radius']) return makeCircle(props)
  else if (props['shape-radius']) return makeShape(props)
  else if (props['symbol-code']) return makeSymbol(props)
  else if (props['icon-url']) return makeIcon(props)
  else return null
}
```

None of the branches match, `makeImage` returns `null`, and the resulting `ol.style.Style` has no `image`. The feature is attached to the source but renders as nothing on the map.

Missing SIDCs are a legitimate case for live data feeds, so filtering the feature out is not acceptable — we want at least a locatable marker.

## Fix

In `symbol.js`, when neither `svg` nor `sidc` is present, return a fallback blue dot style spec that uses the existing `circle-*` props already supported by `makeCircle`:

```js
if (!sidc) {
  return [{
    id: 'style:default/bluedot',
    'circle-radius': 6,
    'circle-fill-color': 'rgba(51,153,204,1)',
    'circle-line-color': '#ffffff',
    'circle-line-width': 1.5
  }]
}
```

This mirrors OpenLayers' canonical default point style and keeps such features visible without needing new registry entries (unknown IDs pass inline props through — see `styleRegistry.js:192`).

Line/Polygon features without SIDC are unaffected — `shape.js` already falls back to a black default stroke.

## Test plan

- [ ] Push GeoJSON Point features via the LiveDataSource with an `sidc` property → military symbol renders as before
- [ ] Push GeoJSON Point features via the LiveDataSource with a `svg` property → custom SVG renders as before
- [ ] Push GeoJSON Point features via the LiveDataSource **without** `sidc` and without `svg` → blue dot appears at the feature location
- [ ] Push GeoJSON LineString/Polygon features without `sidc` → still render with default black stroke