### PR TITLE
feat: heatmap render mode & FeatureCollection for Live Data Sources

### DIFF
--- a/src/renderer/Clipboard.js
+++ b/src/renderer/Clipboard.js
@@ -7,7 +7,8 @@ const canCopy = id =>
   ID.isLayerId(id) ||
   ID.isFeatureId(id) ||
   ID.isMarkerId(id) ||
-  ID.isTileServiceId(id)
+  ID.isTileServiceId(id) ||
+  ID.isSSEServiceId(id)
 
 /**
  * @async implicit

--- a/src/renderer/components/map/SSEVectorSource.js
+++ b/src/renderer/components/map/SSEVectorSource.js
@@ -84,7 +84,7 @@ class SSEVectorSource extends VectorSource {
       strategy: function (extent, resolution) {
         if (state.resolution !== resolution) {
           state.resolution = resolution
-          this.getFeatures().map(feature => feature.$.centerResolution(resolution))
+          this.getFeatures().forEach(feature => feature.$?.centerResolution(resolution))
         }
         return [extent]
       }
@@ -127,6 +127,30 @@ class SSEVectorSource extends VectorSource {
      * @type {boolean}
      */
     this.useFeatureIds = options.useFeatureIds !== false
+
+    /**
+     * Render mode: 'vector' for normal rendering, 'heatmap' for density visualization
+     * @type {string}
+     */
+    this.renderMode = options.renderMode || 'vector'
+
+    /**
+     * Rate limiting interval for heatmap accumulation in milliseconds
+     * @type {number}
+     */
+    this.heatmapInterval = options.heatmapInterval || 1000
+
+    /**
+     * Timestamp of last heatmap accumulation (ms since epoch)
+     * @type {number}
+     */
+    this.lastHeatmapUpdate = 0
+
+    /**
+     * Maximum number of accumulated heatmap features before oldest are dropped
+     * @type {number}
+     */
+    this.maxHeatmapFeatures = options.maxHeatmapFeatures || 50000
 
     /**
      * Prefix added to feature IDs
@@ -285,6 +309,8 @@ class SSEVectorSource extends VectorSource {
       this.timerId = null
     }
 
+    this.lastHeatmapUpdate = 0
+
     this.dispatchEvent({
       type: 'sse-disconnected',
       source: this
@@ -336,7 +362,13 @@ class SSEVectorSource extends VectorSource {
         console.warn('Unknown feature type ' + this.pendingData.type)
       }
 
-      if (this.useFeatureIds) {
+      if (this.renderMode === 'heatmap') {
+        const now = Date.now()
+        if (now - this.lastHeatmapUpdate >= this.heatmapInterval) {
+          this.accumulateFeatures(features)
+          this.lastHeatmapUpdate = now
+        }
+      } else if (this.useFeatureIds) {
         this.updateFeaturesById(features)
       } else {
         this.replaceAllFeatures(features)
@@ -399,6 +431,37 @@ class SSEVectorSource extends VectorSource {
       return this.featureReader(reprojectedFeature)
     })
     this.addFeatures(olFeatures)
+  }
+
+  /**
+   * Accumulates features without clearing existing ones (for heatmap mode).
+   * Uses lightweight format.readFeature() instead of signal-based featureReader.
+   * Maps properties.confidence to a 'weight' property for heatmap rendering.
+   *
+   * @param {GeoJSONFeature[]} features - Array of GeoJSON features
+   * @returns {void}
+   */
+  accumulateFeatures (features) {
+    const olFeatures = features.map(feature => {
+      const reprojectedFeature = {
+        ...feature,
+        geometry: this.reprojectGeometry(feature.geometry)
+      }
+      const olFeature = format.readFeature(reprojectedFeature)
+      const confidence = feature.properties?.confidence
+      olFeature.set('weight', confidence != null ? confidence : 0.5)
+      return olFeature
+    })
+    this.addFeatures(olFeatures)
+
+    // Evict oldest features when cap is exceeded
+    const all = this.getFeatures()
+    const excess = all.length - this.maxHeatmapFeatures
+    if (excess > 0) {
+      for (let i = 0; i < excess; i++) {
+        this.removeFeature(all[i])
+      }
+    }
   }
 
   /**

--- a/src/renderer/components/map/SSEVectorSource.js
+++ b/src/renderer/components/map/SSEVectorSource.js
@@ -233,7 +233,13 @@ class SSEVectorSource extends VectorSource {
       try {
         /** @type {GeoJSONData} */
         const data = JSON.parse(event.data)
-        if (data.id) {
+        if (data.type === 'FeatureCollection' && data.features) {
+          data.features.forEach(feature => {
+            if (feature.id) {
+              feature.id = `${this.idPrefix}${feature.id}`
+            }
+          })
+        } else if (data.id) {
           data.id = `${this.idPrefix}${data.id}`
         }
         if (this.onMessage) {

--- a/src/renderer/components/properties/SSEServiceProperties.css
+++ b/src/renderer/components/properties/SSEServiceProperties.css
@@ -1,3 +1,32 @@
+.sse-section-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #666;
+}
+
+.sse-render-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 0;
+}
+
+.sse-radio-group {
+  display: flex;
+  gap: 16px;
+}
+
+.sse-radio-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.sse-radio-label input:disabled + span {
+  color: #999;
+}
+
 .sse-option-row {
   display: flex;
   align-items: center;

--- a/src/renderer/components/properties/SSEServiceProperties.js
+++ b/src/renderer/components/properties/SSEServiceProperties.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react'
 import TextField from './TextField'
+import Range from './Range'
 import FlexColumnGap from './FlexColumnGap'
 import Name from './Name'
 import { useServices } from '../hooks'
@@ -13,7 +14,16 @@ const SSEServiceProperties = props => {
   const [url, setUrl] = React.useState({ dirty: false, value: service.url || '' })
   const [eventType, setEventType] = React.useState({ dirty: false, value: service.eventType || 'message' })
   const [updateInterval, setUpdateInterval] = React.useState({ dirty: false, value: service.updateInterval || 100 })
+  const [heatmapRadius, setHeatmapRadius] = React.useState({ dirty: false, value: service.heatmapRadius ?? 20 })
+  const [heatmapBlur, setHeatmapBlur] = React.useState({ dirty: false, value: service.heatmapBlur ?? 15 })
+  const [heatmapOpacity, setHeatmapOpacity] = React.useState({ dirty: false, value: service.heatmapOpacity ?? 0.75 })
+  const [heatmapInterval, setHeatmapInterval] = React.useState({ dirty: false, value: service.heatmapInterval ?? 1000 })
+  const [maxHeatmapFeatures, setMaxHeatmapFeatures] = React.useState({ dirty: false, value: service.maxHeatmapFeatures ?? 50000 })
+  const [vectorOpacity, setVectorOpacity] = React.useState({ dirty: false, value: service.vectorOpacity ?? 1 })
   const [stats, setStats] = React.useState({ isConnected: false, featureCount: 0 })
+
+  const renderMode = service.renderMode || 'vector'
+  const isHeatmap = renderMode === 'heatmap'
 
   // Update stats periodically
   React.useEffect(() => {
@@ -33,6 +43,12 @@ const SSEServiceProperties = props => {
     setUrl({ dirty: false, value: service.url || '' })
     setEventType({ dirty: false, value: service.eventType || 'message' })
     setUpdateInterval({ dirty: false, value: service.updateInterval || 100 })
+    setHeatmapRadius({ dirty: false, value: service.heatmapRadius ?? 20 })
+    setHeatmapBlur({ dirty: false, value: service.heatmapBlur ?? 15 })
+    setHeatmapOpacity({ dirty: false, value: service.heatmapOpacity ?? 0.75 })
+    setHeatmapInterval({ dirty: false, value: service.heatmapInterval ?? 1000 })
+    setMaxHeatmapFeatures({ dirty: false, value: service.maxHeatmapFeatures ?? 50000 })
+    setVectorOpacity({ dirty: false, value: service.vectorOpacity ?? 1 })
   }, [key]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const updateService = async (updates) => {
@@ -74,6 +90,71 @@ const SSEServiceProperties = props => {
     if (!updateInterval.dirty) return
     setUpdateInterval({ dirty: false, value: updateInterval.value })
     updateService({ updateInterval: updateInterval.value })
+  }
+
+  const handleRenderModeChange = (mode) => {
+    if (mode === renderMode) return
+    updateService({ renderMode: mode })
+  }
+
+  const handleHeatmapRadiusChange = ({ target }) => {
+    const value = parseInt(target.value, 10) || 20
+    if (heatmapRadius.value === value) return
+    setHeatmapRadius({ dirty: true, value })
+  }
+
+  const handleHeatmapRadiusBlur = () => {
+    if (!heatmapRadius.dirty) return
+    setHeatmapRadius({ dirty: false, value: heatmapRadius.value })
+    updateService({ heatmapRadius: heatmapRadius.value })
+  }
+
+  const handleHeatmapBlurChange = ({ target }) => {
+    const value = parseInt(target.value, 10) || 15
+    if (heatmapBlur.value === value) return
+    setHeatmapBlur({ dirty: true, value })
+  }
+
+  const handleHeatmapBlurBlur = () => {
+    if (!heatmapBlur.dirty) return
+    setHeatmapBlur({ dirty: false, value: heatmapBlur.value })
+    updateService({ heatmapBlur: heatmapBlur.value })
+  }
+
+  const handleHeatmapOpacityChange = ({ target }) => {
+    const value = Number.parseFloat(target.value)
+    setHeatmapOpacity({ dirty: false, value })
+    updateService({ heatmapOpacity: value })
+  }
+
+  const handleHeatmapIntervalChange = ({ target }) => {
+    const value = parseInt(target.value, 10) || 1000
+    if (heatmapInterval.value === value) return
+    setHeatmapInterval({ dirty: true, value })
+  }
+
+  const handleHeatmapIntervalBlur = () => {
+    if (!heatmapInterval.dirty) return
+    setHeatmapInterval({ dirty: false, value: heatmapInterval.value })
+    updateService({ heatmapInterval: heatmapInterval.value })
+  }
+
+  const handleMaxHeatmapFeaturesChange = ({ target }) => {
+    const value = parseInt(target.value, 10) || 50000
+    if (maxHeatmapFeatures.value === value) return
+    setMaxHeatmapFeatures({ dirty: true, value })
+  }
+
+  const handleMaxHeatmapFeaturesBlur = () => {
+    if (!maxHeatmapFeatures.dirty) return
+    setMaxHeatmapFeatures({ dirty: false, value: maxHeatmapFeatures.value })
+    updateService({ maxHeatmapFeatures: maxHeatmapFeatures.value })
+  }
+
+  const handleVectorOpacityChange = ({ target }) => {
+    const value = Number.parseFloat(target.value)
+    setVectorOpacity({ dirty: false, value })
+    updateService({ vectorOpacity: value })
   }
 
   const handleEnabledChange = ({ target }) => {
@@ -126,18 +207,123 @@ const SSEServiceProperties = props => {
       />
       <Tooltip anchorSelect='#sse-update-interval' content='Rate limiting interval in milliseconds' delayShow={750} />
 
-      <div className='sse-option-row'>
-        <label className='sse-option-label'>
-          <input
-            type='checkbox'
-            checked={service.useFeatureIds !== false}
-            disabled={isConnected}
-            onChange={handleUseFeatureIdsChange}
-          />
-          <span>Track features by ID</span>
-        </label>
+      <div className='sse-render-mode'>
+        <span className='sse-section-label'>Render Mode</span>
+        <div className='sse-radio-group'>
+          <label className='sse-radio-label'>
+            <input
+              type='radio'
+              name={`renderMode-${key}`}
+              value='vector'
+              checked={!isHeatmap}
+              disabled={isConnected}
+              onChange={() => handleRenderModeChange('vector')}
+            />
+            <span>Vector</span>
+          </label>
+          <label className='sse-radio-label'>
+            <input
+              type='radio'
+              name={`renderMode-${key}`}
+              value='heatmap'
+              checked={isHeatmap}
+              disabled={isConnected}
+              onChange={() => handleRenderModeChange('heatmap')}
+            />
+            <span>Heatmap</span>
+          </label>
+        </div>
       </div>
-      <Tooltip anchorSelect='.sse-option-row' content='When enabled, features are updated by ID. When disabled, all features are replaced on each update.' delayShow={750} />
+      <Tooltip anchorSelect='.sse-render-mode' content='Vector shows individual features, Heatmap shows accumulated detection density' delayShow={750} />
+
+      {isHeatmap && (
+        <>
+          <label className='sse-section-label'>Opacity</label>
+          <Range
+            min='0'
+            max='1'
+            step='0.05'
+            value={heatmapOpacity.value}
+            onChange={handleHeatmapOpacityChange}
+          >
+            <option value='0'>0%</option>
+            <option value='1'>100%</option>
+          </Range>
+
+          <TextField
+            id='sse-heatmap-radius'
+            label='Radius (px)'
+            type='number'
+            min='1'
+            value={heatmapRadius.value}
+            onChange={handleHeatmapRadiusChange}
+            onBlur={handleHeatmapRadiusBlur}
+          />
+          <Tooltip anchorSelect='#sse-heatmap-radius' content='Pixel radius for each heatmap point' delayShow={750} />
+
+          <TextField
+            id='sse-heatmap-blur'
+            label='Blur (px)'
+            type='number'
+            min='1'
+            value={heatmapBlur.value}
+            onChange={handleHeatmapBlurChange}
+            onBlur={handleHeatmapBlurBlur}
+          />
+          <Tooltip anchorSelect='#sse-heatmap-blur' content='Pixel blur around each heatmap point' delayShow={750} />
+
+          <TextField
+            id='sse-heatmap-interval'
+            label='Accumulation Interval (ms)'
+            type='number'
+            min='100'
+            value={heatmapInterval.value}
+            onChange={handleHeatmapIntervalChange}
+            onBlur={handleHeatmapIntervalBlur}
+          />
+          <Tooltip anchorSelect='#sse-heatmap-interval' content='How often detection points are added to the heatmap (slower = less dense)' delayShow={750} />
+
+          <TextField
+            id='sse-max-heatmap-features'
+            label='History Size'
+            type='number'
+            min='1000'
+            value={maxHeatmapFeatures.value}
+            onChange={handleMaxHeatmapFeaturesChange}
+            onBlur={handleMaxHeatmapFeaturesBlur}
+          />
+          <Tooltip anchorSelect='#sse-max-heatmap-features' content='Number of detection points kept in the heatmap. Oldest points are discarded when this limit is reached.' delayShow={750} />
+        </>
+      )}
+
+      {!isHeatmap && (
+        <>
+          <label className='sse-section-label'>Opacity</label>
+          <Range
+            min='0'
+            max='1'
+            step='0.05'
+            value={vectorOpacity.value}
+            onChange={handleVectorOpacityChange}
+          >
+            <option value='0'>0%</option>
+            <option value='1'>100%</option>
+          </Range>
+
+          <div className='sse-option-row'>
+            <label className='sse-option-label'>
+              <input
+                type='checkbox'
+                checked={service.useFeatureIds !== false}
+                disabled={isConnected}
+                onChange={handleUseFeatureIdsChange}
+              />
+              <span>Track features by ID</span>
+            </label>
+          </div>
+          <Tooltip anchorSelect='.sse-option-row' content='When enabled, features are updated by ID. When disabled, all features are replaced on each update.' delayShow={750} />
+        </>
+      )}
 
       <div className='sse-enabled-row'>
         <label className='sse-enabled-label'>

--- a/src/renderer/components/properties/SSEServiceProperties.js
+++ b/src/renderer/components/properties/SSEServiceProperties.js
@@ -8,6 +8,75 @@ import { useServices } from '../hooks'
 import { Tooltip } from 'react-tooltip'
 import './SSEServiceProperties.css'
 
+/**
+ * Displays the connection status indicator (green/gray dot with text).
+ * Polls independently so re-renders don't affect the parent form.
+ */
+const SSEConnectionStatus = ({ sseLayerStore, serviceKey }) => {
+  const [connected, setConnected] = React.useState(false)
+
+  React.useEffect(() => {
+    const check = () => {
+      if (sseLayerStore) {
+        const stats = sseLayerStore.getServiceStats(serviceKey)
+        setConnected(!!stats.isConnected)
+      }
+    }
+    check()
+    const interval = setInterval(check, 1000)
+    return () => clearInterval(interval)
+  }, [serviceKey, sseLayerStore])
+
+  const className = connected
+    ? 'sse-status sse-status--connected'
+    : 'sse-status sse-status--disconnected'
+
+  return (
+    <div className={className}>
+      <span className='sse-status-indicator'></span>
+      <span>{connected ? 'Connected' : 'Disconnected'}</span>
+    </div>
+  )
+}
+
+/**
+ * Displays live stats (feature count, messages, updates).
+ * Polls independently so re-renders don't affect the parent form.
+ */
+const SSEServiceStatsPanel = ({ sseLayerStore, serviceKey }) => {
+  const [stats, setStats] = React.useState(null)
+
+  React.useEffect(() => {
+    const update = () => {
+      if (sseLayerStore) {
+        setStats(sseLayerStore.getServiceStats(serviceKey))
+      }
+    }
+    update()
+    const interval = setInterval(update, 1000)
+    return () => clearInterval(interval)
+  }, [serviceKey, sseLayerStore])
+
+  if (!stats?.isConnected) return null
+
+  return (
+    <div className='sse-stats'>
+      <div className='sse-stat'>
+        <span className='sse-stat-label'>Features:</span>
+        <span className='sse-stat-value'>{stats.featureCount}</span>
+      </div>
+      <div className='sse-stat'>
+        <span className='sse-stat-label'>Messages:</span>
+        <span className='sse-stat-value'>{stats.messagesReceived}</span>
+      </div>
+      <div className='sse-stat'>
+        <span className='sse-stat-label'>Updates:</span>
+        <span className='sse-stat-value'>{stats.mapUpdates}</span>
+      </div>
+    </div>
+  )
+}
+
 const SSEServiceProperties = props => {
   const { sseLayerStore, store } = useServices()
   const [key, service] = (Object.entries(props.features))[0]
@@ -20,21 +89,24 @@ const SSEServiceProperties = props => {
   const [heatmapInterval, setHeatmapInterval] = React.useState({ dirty: false, value: service.heatmapInterval ?? 1000 })
   const [maxHeatmapFeatures, setMaxHeatmapFeatures] = React.useState({ dirty: false, value: service.maxHeatmapFeatures ?? 50000 })
   const [vectorOpacity, setVectorOpacity] = React.useState({ dirty: false, value: service.vectorOpacity ?? 1 })
-  const [stats, setStats] = React.useState({ isConnected: false, featureCount: 0 })
+  const [connected, setConnected] = React.useState(false)
 
   const renderMode = service.renderMode || 'vector'
   const isHeatmap = renderMode === 'heatmap'
 
-  // Update stats periodically
+  // Track connection status as a primitive boolean.
+  // React skips re-renders when the value hasn't changed,
+  // so this won't cause re-renders during steady streaming.
   React.useEffect(() => {
-    const updateStats = () => {
+    const checkConnection = () => {
       if (sseLayerStore) {
-        setStats(sseLayerStore.getServiceStats(key))
+        const stats = sseLayerStore.getServiceStats(key)
+        setConnected(!!stats.isConnected)
       }
     }
 
-    updateStats()
-    const interval = setInterval(updateStats, 1000)
+    checkConnection()
+    const interval = setInterval(checkConnection, 1000)
     return () => clearInterval(interval)
   }, [key, sseLayerStore])
 
@@ -165,12 +237,7 @@ const SSEServiceProperties = props => {
     updateService({ useFeatureIds: target.checked })
   }
 
-  const connectionStatusClass = stats.isConnected
-    ? 'sse-status sse-status--connected'
-    : 'sse-status sse-status--disconnected'
-
-  const connectionStatusText = stats.isConnected ? 'Connected' : 'Disconnected'
-  const isConnected = service.enabled && stats.isConnected
+  const isConnected = service.enabled && connected
 
   return (
     <FlexColumnGap>
@@ -334,28 +401,10 @@ const SSEServiceProperties = props => {
           />
           <span>Enabled</span>
         </label>
-        <div className={connectionStatusClass}>
-          <span className='sse-status-indicator'></span>
-          <span>{connectionStatusText}</span>
-        </div>
+        <SSEConnectionStatus sseLayerStore={sseLayerStore} serviceKey={key} />
       </div>
 
-      {stats.isConnected && (
-        <div className='sse-stats'>
-          <div className='sse-stat'>
-            <span className='sse-stat-label'>Features:</span>
-            <span className='sse-stat-value'>{stats.featureCount}</span>
-          </div>
-          <div className='sse-stat'>
-            <span className='sse-stat-label'>Messages:</span>
-            <span className='sse-stat-value'>{stats.messagesReceived}</span>
-          </div>
-          <div className='sse-stat'>
-            <span className='sse-stat-label'>Updates:</span>
-            <span className='sse-stat-value'>{stats.mapUpdates}</span>
-          </div>
-        </div>
-      )}
+      <SSEServiceStatsPanel sseLayerStore={sseLayerStore} serviceKey={key} />
     </FlexColumnGap>
   )
 }

--- a/src/renderer/components/properties/SSEServiceProperties.js
+++ b/src/renderer/components/properties/SSEServiceProperties.js
@@ -153,15 +153,16 @@ const SSEServiceProperties = props => {
   }
 
   const handleUpdateIntervalChange = ({ target }) => {
-    const value = parseInt(target.value, 10) || 100
-    if (updateInterval.value === value) return
-    setUpdateInterval({ dirty: true, value })
+    if (updateInterval.value === target.value) return
+    setUpdateInterval({ dirty: true, value: target.value })
   }
 
   const handleUpdateIntervalBlur = () => {
     if (!updateInterval.dirty) return
-    setUpdateInterval({ dirty: false, value: updateInterval.value })
-    updateService({ updateInterval: updateInterval.value })
+    const parsed = parseInt(updateInterval.value, 10)
+    const value = Number.isFinite(parsed) && parsed > 0 ? parsed : 100
+    setUpdateInterval({ dirty: false, value })
+    updateService({ updateInterval: value })
   }
 
   const handleRenderModeChange = (mode) => {
@@ -170,27 +171,29 @@ const SSEServiceProperties = props => {
   }
 
   const handleHeatmapRadiusChange = ({ target }) => {
-    const value = parseInt(target.value, 10) || 20
-    if (heatmapRadius.value === value) return
-    setHeatmapRadius({ dirty: true, value })
+    if (heatmapRadius.value === target.value) return
+    setHeatmapRadius({ dirty: true, value: target.value })
   }
 
   const handleHeatmapRadiusBlur = () => {
     if (!heatmapRadius.dirty) return
-    setHeatmapRadius({ dirty: false, value: heatmapRadius.value })
-    updateService({ heatmapRadius: heatmapRadius.value })
+    const parsed = parseInt(heatmapRadius.value, 10)
+    const value = Number.isFinite(parsed) && parsed > 0 ? parsed : 20
+    setHeatmapRadius({ dirty: false, value })
+    updateService({ heatmapRadius: value })
   }
 
   const handleHeatmapBlurChange = ({ target }) => {
-    const value = parseInt(target.value, 10) || 15
-    if (heatmapBlur.value === value) return
-    setHeatmapBlur({ dirty: true, value })
+    if (heatmapBlur.value === target.value) return
+    setHeatmapBlur({ dirty: true, value: target.value })
   }
 
   const handleHeatmapBlurBlur = () => {
     if (!heatmapBlur.dirty) return
-    setHeatmapBlur({ dirty: false, value: heatmapBlur.value })
-    updateService({ heatmapBlur: heatmapBlur.value })
+    const parsed = parseInt(heatmapBlur.value, 10)
+    const value = Number.isFinite(parsed) && parsed >= 0 ? parsed : 15
+    setHeatmapBlur({ dirty: false, value })
+    updateService({ heatmapBlur: value })
   }
 
   const handleHeatmapOpacityChange = ({ target }) => {
@@ -200,27 +203,29 @@ const SSEServiceProperties = props => {
   }
 
   const handleHeatmapIntervalChange = ({ target }) => {
-    const value = parseInt(target.value, 10) || 1000
-    if (heatmapInterval.value === value) return
-    setHeatmapInterval({ dirty: true, value })
+    if (heatmapInterval.value === target.value) return
+    setHeatmapInterval({ dirty: true, value: target.value })
   }
 
   const handleHeatmapIntervalBlur = () => {
     if (!heatmapInterval.dirty) return
-    setHeatmapInterval({ dirty: false, value: heatmapInterval.value })
-    updateService({ heatmapInterval: heatmapInterval.value })
+    const parsed = parseInt(heatmapInterval.value, 10)
+    const value = Number.isFinite(parsed) && parsed > 0 ? parsed : 1000
+    setHeatmapInterval({ dirty: false, value })
+    updateService({ heatmapInterval: value })
   }
 
   const handleMaxHeatmapFeaturesChange = ({ target }) => {
-    const value = parseInt(target.value, 10) || 50000
-    if (maxHeatmapFeatures.value === value) return
-    setMaxHeatmapFeatures({ dirty: true, value })
+    if (maxHeatmapFeatures.value === target.value) return
+    setMaxHeatmapFeatures({ dirty: true, value: target.value })
   }
 
   const handleMaxHeatmapFeaturesBlur = () => {
     if (!maxHeatmapFeatures.dirty) return
-    setMaxHeatmapFeatures({ dirty: false, value: maxHeatmapFeatures.value })
-    updateService({ maxHeatmapFeatures: maxHeatmapFeatures.value })
+    const parsed = parseInt(maxHeatmapFeatures.value, 10)
+    const value = Number.isFinite(parsed) && parsed > 0 ? parsed : 50000
+    setMaxHeatmapFeatures({ dirty: false, value })
+    updateService({ maxHeatmapFeatures: value })
   }
 
   const handleVectorOpacityChange = ({ target }) => {

--- a/src/renderer/ids.js
+++ b/src/renderer/ids.js
@@ -219,12 +219,16 @@ export const associatedId = id => {
     : id.substring(indexStart + 1)
 }
 
+// Entity types must sort before their dependent entries (link, tags, style),
+// because clone() rewrites dependent keys via a keymap populated when the
+// owning entity is processed.
 export const ord = R.cond([
   [isLayerId, R.always(0)],
   [isFeatureId, R.always(1)],
   [isMarkerId, R.always(2)],
-  [isLinkId, R.always(3)],
-  [isTagsId, R.always(4)],
-  [isStyleId, R.always(5)],
-  [isTileServiceId, R.always(6)]
+  [isTileServiceId, R.always(3)],
+  [isSSEServiceId, R.always(4)],
+  [isLinkId, R.always(5)],
+  [isTagsId, R.always(6)],
+  [isStyleId, R.always(7)]
 ])

--- a/src/renderer/model/Import.js
+++ b/src/renderer/model/Import.js
@@ -1,5 +1,6 @@
 import * as R from 'ramda'
 import * as ID from '../ids'
+import uuid from '../../shared/uuid'
 
 export const clone = async (defaultLayerId, unsorted) => {
   const entries = unsorted.sort(([a], [b]) => ID.ord(a) - ID.ord(b))
@@ -45,13 +46,22 @@ export const clone = async (defaultLayerId, unsorted) => {
     [ID.isTagsId, key => replace(key)(ID.tagsId(keymap[ID.associatedId(key)]))],
     [ID.isMarkerId, key => replace(key)(ID.markerId())],
     [ID.isTileServiceId, key => replace(key)(ID.tileServiceId())],
+    [ID.isSSEServiceId, key => replace(key)(ID.sseServiceId())],
     [ID.isStyleId, key => replace(key)(ID.styleId(keymap[ID.associatedId(key)]))],
     [R.T, key => key]
   ])
 
+  // Rewrite values where a plain key remap is not sufficient.
+  // A duplicated live data source must not share the original's
+  // feature namespace and must not auto-connect.
+
+  const rewriteValue = (key, value) => ID.isSSEServiceId(key)
+    ? { ...value, enabled: false, featureIdPrefix: `feature:${uuid()}/` }
+    : value
+
   // Nasty side-effect: adds tuples (aka acc):
   entries.reduce((acc, [key, value]) => {
-    acc.push([rewrite(key), value])
+    acc.push([rewrite(key), rewriteValue(key, value)])
     return acc
   }, tuples)
 

--- a/src/renderer/model/commands/CreationCommands.js
+++ b/src/renderer/model/commands/CreationCommands.js
@@ -104,7 +104,14 @@ CreateSSEService.prototype.execute = function () {
     dataProjection: 'EPSG:4326',
     updateInterval: 100,
     featureIdPrefix: `feature:${layerId}/`,
-    useFeatureIds: true
+    useFeatureIds: true,
+    renderMode: 'vector',
+    heatmapRadius: 20,
+    heatmapBlur: 15,
+    heatmapOpacity: 0.75,
+    heatmapInterval: 1000,
+    maxHeatmapFeatures: 50000,
+    vectorOpacity: 1
   }]])
   this.selection.focus(key)
 }

--- a/src/renderer/store/SSELayerStore.js
+++ b/src/renderer/store/SSELayerStore.js
@@ -1,5 +1,6 @@
 import Collection from 'ol/Collection'
 import LayerGroup from 'ol/layer/Group'
+import HeatmapLayer from 'ol/layer/Heatmap'
 import VectorLayer from 'ol/layer/Vector'
 import * as ID from '../ids'
 import SSEVectorSource from '../components/map/SSEVectorSource'
@@ -28,7 +29,7 @@ SSELayerStore.prototype.bootstrap = async function () {
 }
 
 /**
- * Create LayerGroup with VectorLayers for enabled services.
+ * Create LayerGroup with layers for enabled services.
  */
 SSELayerStore.prototype.sseLayers = async function () {
   const services = await this.store.tuples(ID.SSE_SERVICE_SCOPE)
@@ -39,18 +40,30 @@ SSELayerStore.prototype.sseLayers = async function () {
     }
   }
 
-  this.layerCollection = new Collection(Array.from(this.layers.values()).map(({ layer }) => layer))
+  const heatmapLayers = []
+  const vectorLayers = []
+  for (const { layer } of this.layers.values()) {
+    if (layer instanceof HeatmapLayer) {
+      heatmapLayers.push(layer)
+    } else {
+      vectorLayers.push(layer)
+    }
+  }
+
+  this.layerCollection = new Collection([...heatmapLayers, ...vectorLayers])
   this.layerGroup = new LayerGroup({ layers: this.layerCollection })
   return [this.layerGroup]
 }
 
 /**
- * Create VectorLayer with SSEVectorSource for a service.
+ * Create a VectorLayer or HeatmapLayer with SSEVectorSource for a service.
  */
 SSELayerStore.prototype.createLayer = function (key, service) {
   if (this.layers.has(key)) {
     return this.layers.get(key)
   }
+
+  const renderMode = service.renderMode || 'vector'
 
   const source = new SSEVectorSource({
     sseUrl: service.url,
@@ -58,13 +71,29 @@ SSELayerStore.prototype.createLayer = function (key, service) {
     dataProjection: service.dataProjection || 'EPSG:4326',
     updateInterval: service.updateInterval || 100,
     idPrefix: service.featureIdPrefix || 'feature:',
-    useFeatureIds: service.useFeatureIds !== false
+    useFeatureIds: service.useFeatureIds !== false,
+    renderMode,
+    heatmapInterval: service.heatmapInterval ?? 1000,
+    maxHeatmapFeatures: service.maxHeatmapFeatures ?? 50000
   })
 
-  const layer = new VectorLayer({
-    source,
-    id: key
-  })
+  let layer
+  if (renderMode === 'heatmap') {
+    layer = new HeatmapLayer({
+      source,
+      id: key,
+      blur: service.heatmapBlur ?? 15,
+      radius: service.heatmapRadius ?? 20,
+      opacity: service.heatmapOpacity ?? 0.75,
+      weight: feature => feature.get('weight') ?? 0.5
+    })
+  } else {
+    layer = new VectorLayer({
+      source,
+      id: key,
+      opacity: service.vectorOpacity ?? 1
+    })
+  }
 
   this.layers.set(key, { layer, source })
 
@@ -95,7 +124,29 @@ SSELayerStore.prototype.updateOrCreateService = function (key, service) {
   const existing = this.layers.get(key)
 
   if (existing) {
-    const { source } = existing
+    const { source, layer } = existing
+
+    // Render mode change requires full layer recreate
+    const renderMode = service.renderMode || 'vector'
+    if (source.renderMode !== renderMode) {
+      this.removeLayer(key)
+      if (service.enabled) {
+        const { layer: newLayer } = this.createLayer(key, service)
+        this.insertLayerOrdered(newLayer)
+      }
+      return
+    }
+
+    // Dynamically update layer properties based on mode
+    if (renderMode === 'heatmap' && layer instanceof HeatmapLayer) {
+      layer.setBlur(service.heatmapBlur ?? 15)
+      layer.setRadius(service.heatmapRadius ?? 20)
+      layer.setOpacity(service.heatmapOpacity ?? 0.75)
+      source.heatmapInterval = service.heatmapInterval ?? 1000
+      source.maxHeatmapFeatures = service.maxHeatmapFeatures ?? 50000
+    } else {
+      layer.setOpacity(service.vectorOpacity ?? 1)
+    }
 
     // Check if we need to reconnect due to config changes
     const configChanged = source.sseUrl !== service.url ||
@@ -126,9 +177,24 @@ SSELayerStore.prototype.updateOrCreateService = function (key, service) {
   } else if (service.enabled) {
     // Create new layer for enabled service
     const { layer } = this.createLayer(key, service)
-    if (this.layerCollection) {
+    this.insertLayerOrdered(layer)
+  }
+}
+
+/**
+ * Insert a layer at the correct position: heatmap layers before all vector layers.
+ */
+SSELayerStore.prototype.insertLayerOrdered = function (layer) {
+  if (!this.layerCollection) return
+  if (layer instanceof HeatmapLayer) {
+    const index = this.layerCollection.getArray().findIndex(l => !(l instanceof HeatmapLayer))
+    if (index === -1) {
       this.layerCollection.push(layer)
+    } else {
+      this.layerCollection.insertAt(index, layer)
     }
+  } else {
+    this.layerCollection.push(layer)
   }
 }
 

--- a/src/renderer/store/documents/marker.js
+++ b/src/renderer/store/documents/marker.js
@@ -5,6 +5,8 @@ export default async function (id) {
   const keys = [R.identity, ID.tagsId]
   const [marker, tags] = await this.store.collect(id, keys)
 
+  if (!marker) return null
+
   return {
     id,
     scope: ID.MARKER,

--- a/src/renderer/store/documents/sse-service.js
+++ b/src/renderer/store/documents/sse-service.js
@@ -5,6 +5,8 @@ export default async function (id) {
   const keys = [R.identity, ID.tagsId]
   const [service, tags] = await this.store.collect(id, keys)
 
+  if (!service) return null
+
   const document = {
     id,
     scope: ID.SSE_SERVICE,

--- a/test/renderer/model/Import-test.js
+++ b/test/renderer/model/Import-test.js
@@ -1,0 +1,67 @@
+import assert from 'assert'
+import * as ID from '../../../src/renderer/ids'
+import { clone } from '../../../src/renderer/model/Import'
+
+describe('Import.clone', function () {
+
+  describe('sse-service (live data source)', function () {
+
+    it('rewrites the service key to a new id', async function () {
+      const original = ID.sseServiceId()
+      const entries = [[original, { name: 'Source', enabled: true }]]
+
+      const tuples = await clone(null, entries)
+
+      assert.equal(tuples.length, 1)
+      const [key] = tuples[0]
+      assert(ID.isSSEServiceId(key))
+      assert.notEqual(key, original, 'must not overwrite the original service')
+    })
+
+    it('rewrites the associated tags key to the new service id', async function () {
+      const original = ID.sseServiceId()
+      const entries = [
+        [original, { name: 'Source' }],
+        [ID.tagsId(original), ['Live Data']]
+      ]
+
+      const tuples = await clone(null, entries)
+      const map = Object.fromEntries(tuples)
+
+      const newServiceKey = Object.keys(map).find(ID.isSSEServiceId)
+      const tagsKey = Object.keys(map).find(k => k.startsWith('tags+'))
+      assert.equal(tagsKey, ID.tagsId(newServiceKey), 'tags must follow the new service id')
+      assert.deepEqual(map[tagsKey], ['Live Data'])
+    })
+
+    it('inserts the copy disabled', async function () {
+      const entries = [[ID.sseServiceId(), { name: 'Source', enabled: true }]]
+
+      const tuples = await clone(null, entries)
+
+      assert.equal(tuples[0][1].enabled, false)
+    })
+
+    it('assigns the copy a fresh feature namespace', async function () {
+      const original = ID.sseServiceId()
+      const featureIdPrefix = 'feature:11111111-1111-1111-1111-111111111111/'
+      const entries = [[original, { name: 'Source', featureIdPrefix }]]
+
+      const tuples = await clone(null, entries)
+
+      const value = tuples[0][1]
+      assert.notEqual(value.featureIdPrefix, featureIdPrefix, 'must not share the original namespace')
+      const uuid = value.featureIdPrefix.replace(/^feature:/, '').replace(/\/$/, '')
+      assert(ID.isUUID(uuid), 'featureIdPrefix must reference a valid uuid')
+    })
+
+    it('does not mutate the original value', async function () {
+      const value = { name: 'Source', enabled: true }
+      const entries = [[ID.sseServiceId(), value]]
+
+      await clone(null, entries)
+
+      assert.equal(value.enabled, true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Extends Live Data Sources (SSE) with a heatmap render mode and support for FeatureCollection payloads, enables copy & paste for live data sources, plus a property-panel performance fix.

## Changes

### Features
- Support `FeatureCollection` payloads in SSE streams (in addition to single `Feature`); per-feature IDs are prefixed consistently
- New `heatmap` render mode per SSE service (alternative to `vector`), configurable via `heatmapRadius`, `heatmapBlur`, `heatmapOpacity`, accumulation `heatmapInterval`, and `maxHeatmapFeatures` cap (oldest evicted when exceeded)
- `properties.confidence` is mapped to a `weight` attribute driving heatmap intensity (fallback `0.5`)
- Vector-mode opacity (`vectorOpacity`) now configurable per service
- Live data sources can now be duplicated via copy & paste like other objects: the pasted copy gets a fresh id and feature namespace and is inserted with `enabled: false`

### Fixes
- Extracted connection status and live stats into independent sub-components — their 1 Hz polling no longer triggers re-renders of the surrounding properties form during streaming
- Null-safe access in the SSE resolution strategy
- `ids.ord` now sorts all entity types before their dependent entries (link/tags/style); the previous order processed tags before their owning sse-service/tile-service, leaving the remapped tags key broken on paste
- Guard against a crash when deleting a tagged sse-service or marker: deleting the object emits a del op for its tags entry, which made SearchIndex rebuild the (already removed) owner's document; the sse-service and marker document handlers now return `null` for a missing entry, matching the tile-service/layer handlers

## Spec
`docs/live-data-source.md` documents the base SSE feature. The new `FeatureCollection` support aligns with its "Data Format" section; the `heatmap` render mode is **not yet documented** — follow-up doc update recommended.
