### PR TITLE
chore(deps): upgrade OpenLayers to 10.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "minisearch": "^7.2.0",
         "mousetrap": "^1.6.5",
         "mousetrap-global-bind": "^1.1.0",
-        "ol": "^10.6.1",
+        "ol": "^10.9.0",
         "path-to-regexp": "^8.3.0",
         "proj4": "^2.19.10",
         "ramda": "^0.32.0",
@@ -4168,6 +4168,16 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@zarrita/storage": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
+      "integrity": "sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "reference-spec-reader": "^0.2.0",
+        "unzipit": "2.0.0"
+      }
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -8919,19 +8929,19 @@
       }
     },
     "node_modules/geotiff": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
-      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
+      "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
       "license": "MIT",
       "dependencies": {
-        "@petamoriken/float16": "^3.4.7",
+        "@petamoriken/float16": "^3.9.3",
         "lerc": "^3.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
         "quick-lru": "^6.1.1",
-        "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2",
-        "zstddec": "^0.1.0"
+        "web-worker": "^1.5.0",
+        "xml-utils": "^1.10.2",
+        "zstddec": "^0.2.0"
       },
       "engines": {
         "node": ">=10.19"
@@ -12127,6 +12137,15 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/numcodecs": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+      "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12258,16 +12277,17 @@
       "license": "MIT"
     },
     "node_modules/ol": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-10.7.0.tgz",
-      "integrity": "sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.9.0.tgz",
+      "integrity": "sha512-svbbgVQUmEHaKpLQ8kRySojs59Brvgl2zYIrqG9eQNXGfsbi55rQasZIDpwpQzDL6OlzrUb0H4hQaiX9wDoGmA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/rbush": "4.0.0",
         "earcut": "^3.0.0",
-        "geotiff": "^2.1.3",
+        "geotiff": "^3.0.5 || ^3.1.0-beta.0",
         "pbf": "4.0.1",
-        "rbush": "^4.0.0"
+        "rbush": "^4.0.0",
+        "zarrita": "^0.7.1"
       },
       "funding": {
         "type": "opencollective",
@@ -13431,6 +13451,12 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/reference-spec-reader": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+      "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
+      "license": "MIT"
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
@@ -15802,6 +15828,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unzipit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
+      "integrity": "sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -16808,10 +16843,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zarrita": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.3.tgz",
+      "integrity": "sha512-wChTQ1Ox75INoQCzKAfLWAfB70JJ4KjdW8Sz5x4ZWrFB4Dw+YZdnxHTL0xSdsrB9EmKSeK7fS1Y+I2ibhfGbkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zarrita/storage": "^0.2.0",
+        "numcodecs": "^0.3.2"
+      }
+    },
     "node_modules/zstddec": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+      "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
       "license": "MIT AND BSD-3-Clause"
     }
   }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "minisearch": "^7.2.0",
     "mousetrap": "^1.6.5",
     "mousetrap-global-bind": "^1.1.0",
-    "ol": "^10.6.1",
+    "ol": "^10.9.0",
     "path-to-regexp": "^8.3.0",
     "proj4": "^2.19.10",
     "ramda": "^0.32.0",


### PR DESCRIPTION
## Summary
Upgrades OpenLayers from 10.7.0 to 10.9.0 — a minor bump with no breaking changes.

## Changes
- `ol` 10.7.0 → 10.9.0 (`package.json` `^10.9.0`)

## Breaking change review
OpenLayers' `changelog/upgrade-notes.md` documents **no** breaking changes, removed APIs or new deprecations for 10.8 or 10.9 — the last documented upgrade note is for 10.7.0, which we are already past. The only changes relevant to our usage are non-breaking behavior fixes:
- Hit detection now accounts for the default stroke; VectorTile hit detection beyond tile boundaries corrected (we use `VectorLayer`, not `VectorTile`)
- Trackpad pinch-to-zoom feel
- Improved WebGL rendering precision when zoomed in (`WebGLTile` layer)

Our OpenLayers surface (~40 submodules: `Map`, `View`, `Feature`, `geom/*`, `layer/*`, `source/*`, `interaction/Draw`, `format/GeoJSON|WMSCapabilities|WMTSCapabilities`, `proj`, `style`) uses only stable, unchanged API.

## Validation
- `npm run lint`: clean
- Full test suite: 332 passing
- Manual check confirmed OK (map rendering, selection, drawing, WMS/WMTS layers)
