### PR TITLE
fix(build): align electron-builder with Electron 42 and remove version drift

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -51,5 +51,3 @@ snap:
 publish:
   - provider: github
     releaseType: release
-
-electronVersion: 42.2.0

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -52,4 +52,4 @@ publish:
   - provider: github
     releaseType: release
 
-electronVersion: 38.8.0
+electronVersion: 42.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -11957,9 +11957,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.26.0.tgz",
-      "integrity": "sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
+      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
       "react": "^18.0.0"
     },
     "serialize-javascript": "^7.0.5",
-    "diff": "^9.0.0"
+    "diff": "^9.0.0",
+    "node-abi": "^4.31.0"
   },
   "dependencies": {
     "@mdi/js": "^7.0.96",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,13 @@
 const path = require('path')
-const fs = require('fs')
 const { spawn } = require('child_process')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const webpack = require('webpack')
-const YAML = require('yaml')
 
-// Pick up Electron version [X.Y] from builder configuration:
+// Pick up Electron version [X.Y] from the installed electron package.
+// This is the single source of truth — electron-builder auto-detects the
+// same dependency, so the build target and the packaged runtime cannot drift.
 const { rendererTarget, mainTarget, preloadTarget } = (() => {
-  const file = fs.readFileSync('./electron-builder.yml', 'utf8')
-  const configuration = YAML.parse(file)
-  const version = configuration.electronVersion.match(/(\d+\.\d+)/)[0]
+  const version = require('electron/package.json').version.match(/(\d+\.\d+)/)[0]
 
   return {
     rendererTarget: 'electron' + version + '-renderer',


### PR DESCRIPTION
## Summary
PR #117 bumped the `electron` devDependency to 42.2.0 but left `electron-builder.yml` pinned at `electronVersion: 38.8.0`. That field is the single source of truth for both packaging and the webpack build target (`webpack.config.js` derives the `electronXX-*` target from it), so release builds would have bundled Electron 38 — leaving the audit advisories #117 set out to close present in shipped artifacts.

This PR repairs the drift and removes the duplication that caused it.

## Impact
No released artifact is affected: the Electron 42 bump is in no tagged release (the latest, v3.3.0, predates it by ~2 months). This lands before the next release.

## Changes
- **electron-builder.yml** — drop `electronVersion`. With the field absent, electron-builder auto-detects the version from the installed `electron` dependency.
- **webpack.config.js** — derive the build target from `require('electron/package.json').version` instead of parsing electron-builder.yml; drop the now-unused `fs` and `yaml` requires.
- **package.json** — pin `node-abi` to `^4.31.0` via `overrides`. Bumping the Electron version surfaced that `node-abi@4.26.0` (under `@electron/rebuild`) cannot detect the Electron 42 ABI, which fails `electron-builder install-app-deps`.

## Result
The `electron` dependency is now the single source of the Electron version. Both packaging and the webpack target read the installed package, so they cannot drift apart again.

## Validation
- `electron-builder install-app-deps` auto-detects `electronVersion=42.2.0` and rebuilds `leveldown` for it
- `webpack` compiles with the `electron42.2-*` target
- `npm run lint` clean · 332 tests passing · `npm audit` 0 findings
