### PR TITLE
Fix feature/layer styles dropped on import until refresh

### DIFF
--- a/src/renderer/model/sources/featureSource.js
+++ b/src/renderer/model/sources/featureSource.js
@@ -167,7 +167,10 @@ export const featureSource = services => {
 
   layerStyle.on(({ type, key, value }) => {
     const layerId = ID.layerId(key)
+    // Keep state.styles in sync so features created later in the same batch
+    // (readFeature reads their initial style from state.styles) pick it up.
     if (type === 'del') delete state.styles[key]
+    else state.styles[key] = value
     source.getFeatures()
       .filter(feature => ID.layerId(feature.getId()) === layerId)
       .forEach(feature => feature.$.layerStyle(type === 'put' ? value : {}))
@@ -176,7 +179,10 @@ export const featureSource = services => {
   featureStyle.on(({ type, key, value }) => {
     const featureId = ID.featureId(key)
     const feature = getFeatureById(featureId)
+    // Keep state.styles in sync so features created later in the same batch
+    // (readFeature reads their initial style from state.styles) pick it up.
     if (type === 'del') delete state.styles[key]
+    else state.styles[key] = value
     if (feature) feature.$.featureStyle(type === 'put' ? value : {})
   })
 


### PR DESCRIPTION
## Problem

When a layer is imported (drag & drop or paste), feature geometries appear
immediately on the map but their styling (e.g. line colour and width) only
becomes visible after a refresh.

## Root cause

`store.insert` emits a single `batch` containing both the `feature:` entries
and their `style+feature:` entries. `featureSource`'s batch ordering (`ord`)
deliberately processes `put style+` (ord 2) **before** `put feature` (ord 3),
so that the feature created afterwards can read its initial style from
`state.styles` inside `readFeature`.

But the `featureStyle` and `layerStyle` handlers only ever **deleted** from
`state.styles` (on `del`) and never wrote to it on `put`. So on import:

1. the style event fires first, finds no live feature yet (`getFeatureById`
   returns `undefined`) and discards the signal update;
2. `state.styles` still holds the dictionary loaded once at startup, so the
   feature created next initialises with an empty style.

The style only appears after a refresh, when the init block re-reads
`store.dictionary('style+')` from the now-persisted entries.

## Fix

Update `state.styles[key]` on `put` in both the `featureStyle` and
`layerStyle` handlers, matching the intent of the existing batch ordering.
No behaviour change for the already-working in-app editing path.

## Testing

- Imported a layer with per-feature `style+feature:` entries -> styling now
  renders immediately, no refresh needed.
- Editing feature/layer styles on existing features continues to work.